### PR TITLE
fix: include uv.lock in the version commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+
+### Fixed
+
+- Stage uv.lock in the version commit.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ notebook:
 	@uv run jupyter notebook notebooks
 
 version:
-	@git add pyproject.toml
+	@git add pyproject.toml uv.lock
 	@git commit -m "$$(uv version --short)"
 	@git tag --sign "v$$(uv version --short)" -m "$(uv version --short)"
 	@git push --follow-tags

--- a/uv.lock
+++ b/uv.lock
@@ -3344,7 +3344,7 @@ wheels = [
 
 [[package]]
 name = "pureskillgg-makenew-pyskill"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Problem

`make version` (run by the `version` workflow after `uv version --bump`) staged only `pyproject.toml`. But `uv version` **re-locks `uv.lock`** too, so the lockfile's project version bump was discarded — every release shipped with `pyproject.toml` and `uv.lock` out of sync, and the next `format` run committed the lagging `uv.lock` as a spurious "Run format" commit.

## Fix

Stage `uv.lock` alongside `pyproject.toml` in the version target so the release commit is self-consistent.

```make
version:
	@git add pyproject.toml uv.lock
	...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)